### PR TITLE
set default shell - fallback for LDAP

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,5 +85,18 @@
   user:
     name: '{{ item.username }}'
     shell: /bin/zsh
+  register: chsh_result
+  ignore_errors: true
   with_items: '{{ users }}'
   when: users is defined
+
+- debug:
+    msg: 'userinfo: {{ userinfo.results }}'
+  when: userinfo is defined and chsh_result.failed
+
+- name: fallback - set default shell (add to ~/.bashrc)
+  blockinfile:
+    path: '{{ item.home }}/.bashrc'
+    content: zsh
+  with_items: '{{ userinfo.results }}'
+  when: userinfo is defined and chsh_result.failed


### PR DESCRIPTION
On LDAP, ansible.builtin.user: shell fails since the user isn't in /etc/passwd.

This commit adds a workaround for that by calling zsh from the user's ~/.bashrc.

Its an ugly hack, but it works.