### PR TITLE
fix: update loop variable for default shell fallback

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: release-please
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+env:
+  # For release-please, see available types at https://github.com/google-github-actions/release-please-action/tree/v4/?tab=readme-ov-file#release-types-supported
+  PROJECT_TYPE: simple
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: rp
+        if: github.event_name != 'pull_request' && github.ref_name == 'main'
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: ${{ env.PROJECT_TYPE }}
+      - name: Publish Ansible role to Galaxy
+        if: ${{ steps.rp.outputs.release_created }}
+        uses: robertdebock/galaxy-action@1.2.1
+        with:
+          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
+          git_branch: main

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,10 +101,10 @@
 - name: fallback - set default shell (add to ~/.bashrc)
   become: yes
   blockinfile:
-    path: '{{ item.home }}/.bashrc'
+    path: '{{ item.item.home }}/.bashrc'
     content: zsh
-  with_items: '{{ userinfo.results }}'
-  when: userinfo is defined and chsh_result.failed
+  with_items: '{{ chsh_result.results }}'
+  when: userinfo is defined and item.failed
 
 - name: Change permissions back to user
   become: true


### PR DESCRIPTION
I got surprised when the latest update of this role broke my playbook, so I investigated on my end and discovered this issue.

Since the first "set default shell" method is executed in a loop, its result is actually an array with each item of the loop, making it both possible to reuse the initial items, and get the result (failed or not) of each item individually